### PR TITLE
feat: site template name includes version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ node_modules
 # resources created during test run
 test/resources/some-site-template/site-template
 test/resources/some-site-template/site.template/target
-test/resources/some-site-template/site-template.zip
+test/resources/some-site-template/some-site-template-1.0.0.zip
 test/resources/some-site-template/site.theme/package-lock.json

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ To build your `AEM Site Template` just go into its folder and run command:
 
 ```bash
 npx aem-site-template-builder
-ls -l site-template.zip # done
 ```
 
 ## Expected structure of the repository
@@ -44,7 +43,7 @@ package.json            Includes meta informations.
     - license
 ```
 
-## Compiled site-template.zip
+## Compiled site template artifact
 
 ```bash
 files/                  Optional, folder with the UI kit XD file and possibly other files.

--- a/bin/index.js
+++ b/bin/index.js
@@ -38,6 +38,8 @@ if (!fs.existsSync(THEME_PACKAGE_JSON_PATH)) {
   exitAndPrintError(`Failed to read ${THEME_PACKAGE_JSON_PATH}.`);
 }
 
+const siteTetmplatePackageJson = require(SITE_TEMPLATE_PACKAGE_JSON_PATH);
+
 // Check required commands in the terminal
 terminal.commandCheck('mvn');
 terminal.commandCheck('git');
@@ -86,7 +88,7 @@ shell.echo(terminal.prefix, 'Zipping Site Template package...');
 zip({
   source: `*`,
   cwd: TEMP_FOLDER_NAME,
-  destination: path.join(process.cwd(), `${PATHS.siteTemplate}.zip`)
+  destination: path.join(process.cwd(), `${siteTetmplatePackageJson.name}-${siteTetmplatePackageJson.version}.zip`)
 }).then(function() {
   shell.rm('-rf', TEMP_FOLDER_NAME);
   shell.echo(terminal.prefix, `Site Template package created! ${PATHS.siteTemplate}.zip`);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "aem-site-template-builder": "./bin/index.js"
   },
   "scripts": {
-    "test": "ava"
+    "test": "ava --serial=true"
   },
   "dependencies": {
     "bestzip": "2.1.7",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,22 +1,24 @@
 const test = require('ava');
 const path = require('path');
+const fs = require('fs');
 
-const TEST_TEMPLATE_FOLDER_PATH = path.join(process.cwd(), 'test/resources/some-site-template');
-const UNDER_TEST_PATH = path.join(process.cwd(), 'bin/index.js');
+const ROOT_PATH = process.cwd();
+const TEST_TEMPLATE_FOLDER_PATH = path.join(ROOT_PATH, 'test/resources/some-site-template');
+const UNDER_TEST_PATH = path.join(ROOT_PATH, 'bin/index.js');
 
 test.beforeEach(t => {
     process.chdir(TEST_TEMPLATE_FOLDER_PATH);
 });
 
 test.afterEach.always( async t => {
-    // sleep for a few process cycles to await the childprocess in index.js
-    await new Promise((resolve) => { setTimeout(resolve, 1000); });
-
-    process.chdir(TEST_TEMPLATE_FOLDER_PATH);
+    process.chdir(ROOT_PATH);
     delete require.cache[require.resolve(UNDER_TEST_PATH)];
 });
 
 test('Create site template artifact', async t => {
-    require(path.join(cwd, 'bin/index.js'));
-    t.pass();
+    require(UNDER_TEST_PATH);
+
+    // sleep for a few process cycles to await the childprocess in index.js
+    await new Promise((resolve) => { setTimeout(resolve, 1000); });
+    t.true(fs.existsSync(path.join(TEST_TEMPLATE_FOLDER_PATH, 'some-site-template-1.0.0.zip')));
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,15 +1,22 @@
 const test = require('ava');
 const path = require('path');
 
-test('Create site template artifact', async t => {
-    const cwd = process.cwd();
-    process.chdir(path.join(cwd, 'test/resources/some-site-template'));
-    
-    require(path.join(cwd, 'bin/index.js'));
-    
-    // sleep for a few js cycles to await the childprocess in index.js
+const TEST_TEMPLATE_FOLDER_PATH = path.join(process.cwd(), 'test/resources/some-site-template');
+const UNDER_TEST_PATH = path.join(process.cwd(), 'bin/index.js');
+
+test.beforeEach(t => {
+    process.chdir(TEST_TEMPLATE_FOLDER_PATH);
+});
+
+test.afterEach.always( async t => {
+    // sleep for a few process cycles to await the childprocess in index.js
     await new Promise((resolve) => { setTimeout(resolve, 1000); });
 
-    process.chdir(cwd);
+    process.chdir(TEST_TEMPLATE_FOLDER_PATH);
+    delete require.cache[require.resolve(UNDER_TEST_PATH)];
+});
+
+test('Create site template artifact', async t => {
+    require(path.join(cwd, 'bin/index.js'));
     t.pass();
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Generates artifact name `{projectName}-{version}.zip`. For example, `aem-sites-template-basic-0.0.1.zip` instead of site-template.zip.

<!--- Describe your changes in detail -->

## Related Issue

https://github.com/adobe/aem-site-template-builder/issues/2

## Motivation and Context

## How Has This Been Tested?

unit test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
