### PR TITLE
Build creates additional -latest.zip package file

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -91,6 +91,9 @@ zip({
   cwd: TEMP_FOLDER_NAME,
   destination: path.join(process.cwd(), siteTemplateFileName)
 }).then(function() {
+  const siteTemplateLatestName = `${siteTemplatePackageJson.name}-latest.zip`;
+  // Create additional ${siteTemplateFileName}-latest.zip file as a copy of ${siteTemplateFileName}
+  shell.cp('-r', path.join(process.cwd(), siteTemplateFileName), path.join(process.cwd(), siteTemplateLatestName));
   shell.rm('-rf', TEMP_FOLDER_NAME);
   shell.echo(terminal.prefix, `Site Template package created! ${siteTemplateFileName}`);
 }).catch(function(err) {


### PR DESCRIPTION
Build script creates additional `<name>-latest.zip` file which can be used by deployment scripts in site template without need to generate name dynamically. `<name>-latests.zip` file will get overwritten every time template builder will be used. Version file is still available as `<name>-<version>.zip` as it was before.