### PR TITLE
bugfix: include src in theme-sources structure

### DIFF
--- a/lib/modules/prepareThemeSources.js
+++ b/lib/modules/prepareThemeSources.js
@@ -36,7 +36,7 @@ const prepareThemeSources = async function ({ rootPath } = { rootPath: process.c
   files.forEach((file) => {
     const sourceFilePath = path.join(PATHS.theme, file);
     // Path without the file name is required to not create folder with the file name
-    const destinationFilePath = file.split(path.sep).slice(1, -1).join(path.sep);
+    const destinationFilePath = file.split(path.sep).slice(0, -1).join(path.sep);
     zipTheme.addLocalFile(sourceFilePath, destinationFilePath);
   });
 


### PR DESCRIPTION
Fixes an issue with first level folder in the structure being removed during theme-sources creation. The most obvious was the src folder which was omitted. That caused js, css and resources to be directly accessible in root folder of theme-sources.