### PR TITLE
feat: make site template theme optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ previews/               Folder with screenshots of the site template.
     navigation.png
     teaser.png
 site/                   Content module that contains the templates and policies.
-theme/                  Theme sources (CSS, JS). It's a npm package with dev-dependency to aem-site-theme-builder.
+theme/                  Optional, theme sources (CSS, JS). It's a npm package with dev-dependency to aem-site-theme-builder.
 package.json            Includes meta informations.
     - version           The version of the Site Template.
     - name              Unique name to help AEM to only contain a Site Template once.
@@ -57,8 +57,8 @@ previews/               Folder with screenshots of the site template.
     navigation.png
     teaser.png
 site.zip                Content package that contains the templates and policies.
-theme.zip               Contains compiled theme.
-theme-sources.zip       Zipped theme sources folder.
+theme.zip               Optional, contains compiled theme.
+theme-sources.zip       Optional, zipped theme sources folder.
 ```
 
 ## Local development

--- a/lib/modules/packageSiteTemplate.js
+++ b/lib/modules/packageSiteTemplate.js
@@ -46,8 +46,10 @@ const packageSiteTemplate = async function ({
 
     shell.cp('-r', [PATHS.packageJson], PATHS.tempFolder);
   } else {
-    await prepareCompiledTheme({ rootPath });
-    await prepareThemeSources({ rootPath });
+    if (shell.test('-d', PATHS.theme)) {
+      await prepareCompiledTheme({ rootPath });
+      await prepareThemeSources({ rootPath });
+    }
     await buildContentPackage({ rootPath });
 
     // Copy all part of the Site Template into temp folder

--- a/lib/modules/prerequisitsCheck.js
+++ b/lib/modules/prerequisitsCheck.js
@@ -18,7 +18,10 @@ const { ERRORS, INFO } = require('../i18n');
 const prerequisitsCheck = async function ({ rootPath }) {
   const PATHS = config.generatePaths(rootPath);
   const THEME_PACKAGE_JSON_PATH = path.join(PATHS.theme, 'package.json');
-  const requiredFiles = [PATHS.packageJson, THEME_PACKAGE_JSON_PATH];
+  const requiredFiles = [PATHS.packageJson];
+  if (shell.test('-d', PATHS.theme)) {
+    requiredFiles.push(THEME_PACKAGE_JSON_PATH);
+  }
 
   const commandCheck = command => {
     if (!shell.which(command)) terminal.error(`${ERRORS.command_required} ${command}`);

--- a/test/resources/incorrect-site-template/package.json
+++ b/test/resources/incorrect-site-template/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "incorrect-site-template",
-  "version": "1.0.0",
-  "description": "Incorrect Site Template",
-  "private": true,
-  "license": "MIT License",
-  "devDependencies": {}
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For the XWalk project we will provide site templates which don't include a theme as the frontend code is reused from Edge Delivery. Therefore we have to make the theme subfolder optional in this builder.
